### PR TITLE
Remove $smwgCheckChangesBeforeUpdate

### DIFF
--- a/SemanticWatchlist.php
+++ b/SemanticWatchlist.php
@@ -146,9 +146,6 @@ $wgResourceModules['ext.swl.watchlistconditions'] = $moduleTemplate + array(
 
 require_once 'SemanticWatchlist.settings.php';
 
-// This overrides the default value for the setting in SMW, as the behaviour it enables is used by this extension.
-$smwgCheckChangesBeforeUpdate = true;
-
 $wgAvailableRights[] = 'semanticwatch';
 $wgAvailableRights[] = 'semanticwatchgroups';
 


### PR DESCRIPTION
$smwgCheckChangesBeforeUpdate has been removed with

$ git log -SsmwgCheckChangesBeforeUpdate
commit 26504109157d79565668cf12a1ee89dff74fcf07
Author: Jeroen De Dauw jeroendedauw@users.mediawiki.org
Date:   Sat May 21 19:31:16 2011 +0000

```
moving the change related stuff to SWL
```
