### PR TITLE
SQLite compliant DB schema

### DIFF
--- a/src/Database/SqlDatabaseSchema.sql
+++ b/src/Database/SqlDatabaseSchema.sql
@@ -4,7 +4,7 @@
 
 -- Watchlist groups
 CREATE TABLE IF NOT EXISTS /*$wgDBprefix*/swl_groups (
-  group_id                 SMALLINT unsigned   NOT NULL auto_increment PRIMARY KEY,
+  group_id                 SMALLINT unsigned   NOT NULL PRIMARY KEY AUTO_INCREMENT,
   group_name               VARCHAR(255)        NOT NULL,
   -- No need to have this stuff relational, so keep it simple.
   -- These fields keep multiple values, | separated.
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS /*$wgDBprefix*/swl_groups (
 
 -- Single value changes to a property.
 CREATE TABLE IF NOT EXISTS /*$wgDBprefix*/swl_changes (
-  change_id                INT(10) unsigned    NOT NULL auto_increment PRIMARY KEY,
+  change_id                INT(10) unsigned    NOT NULL PRIMARY KEY AUTO_INCREMENT,
   change_set_id            INT(10) unsigned    NOT NULL, -- Foreign key: swl_sets.set_id
   change_property          VARCHAR(255)        NOT NULL, -- Name of the property of which a value was changed
   change_old_value         BLOB                NULL, -- The old value of the property (null for an adittion)
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS /*$wgDBprefix*/swl_changes (
 
 -- Individual edits to pages.
 CREATE TABLE IF NOT EXISTS /*$wgDBprefix*/swl_edits (
-  edit_id                  SMALLINT unsigned   NOT NULL auto_increment PRIMARY KEY,
+  edit_id                  SMALLINT unsigned   NOT NULL PRIMARY KEY AUTO_INCREMENT,
   edit_user_name           VARCHAR(255)        NOT NULL, -- The person that made the modification (account name or ip)
   edit_page_id             INT(10) unsigned    NOT NULL, -- The id of the page the modification was on  
   edit_time                CHAR(14) binary     NOT NULL default '' -- The time the chages where made  
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS /*$wgDBprefix*/swl_edits (
 
 -- Sets of changes. There can be many such sets for one edit, with overlapping changes.
 CREATE TABLE IF NOT EXISTS /*$wgDBprefix*/swl_sets (
-  set_id                   INT(10) unsigned    NOT NULL auto_increment PRIMARY KEY
+  set_id                   INT(10) unsigned    NOT NULL PRIMARY KEY AUTO_INCREMENT
 ) /*$wgDBTableOptions*/;
 
 -- Links change sets their edits.

--- a/src/MediaWiki/Hooks/ExtensionSchemaUpdater.php
+++ b/src/MediaWiki/Hooks/ExtensionSchemaUpdater.php
@@ -46,13 +46,15 @@ class ExtensionSchemaUpdater {
 	 * @return boolean
 	 */
 	public function execute() {
+		return $this->isSupportedDBType() && $this->hasDatabaseSchema() ? $this->performUpdate() : true;
+	}
 
-		if ( $this->databaseUpdater->getDB()->getType() === 'mysql' &&
-			isset( $this->configuration['egSwlSqlDatabaseSchemaPath'] ) ) {
-			return $this->performUpdate();
-		}
+	private function isSupportedDBType() {
+		return in_array( $this->databaseUpdater->getDB()->getType(), array( 'mysql', 'sqlite' ) );
+	}
 
-		return true;
+	private function hasDatabaseSchema() {
+		return isset( $this->configuration['egSwlSqlDatabaseSchemaPath'] );
 	}
 
 	protected function performUpdate() {

--- a/tests/phpunit/MediaWiki/Hooks/ExtensionSchemaUpdaterTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/ExtensionSchemaUpdaterTest.php
@@ -31,7 +31,7 @@ class ExtensionSchemaUpdaterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testExecuteOnNonMySqlWithoutExtensionUpdate() {
+	public function testNoExtensionUpdateForInvalidDBType() {
 
 		$dbConnection = $this->getMockBuilder( 'DatabaseBase' )
 			->disableOriginalConstructor()
@@ -61,7 +61,10 @@ class ExtensionSchemaUpdaterTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $instance->execute() );
 	}
 
-	public function testExecuteOnMySqlWithExtensionUpdate() {
+	/**
+	 * @dataProvider dbTypeProvider
+	 */
+	public function testExtensionUpdateForValidDBType( $dbType ) {
 
 		$dbConnection = $this->getMockBuilder( 'DatabaseBase' )
 			->disableOriginalConstructor()
@@ -69,7 +72,7 @@ class ExtensionSchemaUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 		$dbConnection->expects( $this->once() )
 			->method( 'getType' )
-			->will( $this->returnValue( 'mysql' ) );
+			->will( $this->returnValue( $dbType ) );
 
 		$databaseUpdater = $this->getMockBuilder( 'DatabaseUpdater' )
 			->disableOriginalConstructor()
@@ -92,6 +95,16 @@ class ExtensionSchemaUpdaterTest extends \PHPUnit_Framework_TestCase {
 		$instance->setConfiguration( $configuration );
 
 		$this->assertTrue( $instance->execute() );
+	}
+
+	public function dbTypeProvider() {
+
+		$provider = array(
+			array( 'sqlite' ),
+			array( 'mysql' )
+		);
+
+		return $provider;
 	}
 
 }


### PR DESCRIPTION
```
SemanticMediaWiki 2.1 (sqlite) test autoloader ...

MediaWiki 1.24.1 root vendor autoloader ...

PHPUnit 4.4.2 by Sebastian Bergmann.

Configuration read from ...\extensions\SemanticWatchlist\phpunit.xml.dist

.......................

Time: 5.58 seconds, Memory: 21.25Mb

OK (23 tests, 49 assertions)
```