### PR TITLE
Fix issue with HTML formatting,  with MediaWiki 1.27+

### DIFF
--- a/includes/SWL_Emailer.php
+++ b/includes/SWL_Emailer.php
@@ -38,7 +38,7 @@ final class SWLEmailer {
 		)->parseAsBlock();
 
 		if ( $describeChanges ) {
-			$emailText .= Html::element( 'h3', array(), wfMessage(
+			$emailText .= Html::rawElement( 'h3', array(), wfMessage(
 				'swl-email-changes',
 				$changeSet->getEdit()->getTitle()->getFullText(),
 				$changeSet->getEdit()->getTitle()->getFullURL()
@@ -51,14 +51,24 @@ final class SWLEmailer {
 
 		wfRunHooks( 'SWLBeforeEmailNotify', array( $group, $user, $changeSet, $describeChanges, &$title, &$emailText ) );
 
-		return UserMailer::send(
-			new MailAddress( $user ),
-			new MailAddress( $wgPasswordSender, $wgPasswordSenderName ),
-			$title,
-			$emailText,
-			null,
-			'text/html; charset=ISO-8859-1'
-		);
+		if ( version_compare( $GLOBALS['wgVersion'], '1.27', '<' ) ) {
+			return UserMailer::send(
+				new MailAddress( $user ),
+				new MailAddress( $wgPasswordSender, $wgPasswordSenderName ),
+				$title,
+				$emailText,
+				null,
+				'text/html; charset=ISO-8859-1'
+			);
+		} else {
+			return UserMailer::send(
+				new MailAddress( $user ),
+				new MailAddress( $wgPasswordSender, $wgPasswordSenderName ),
+				$title,
+				$emailText,
+				array( 'contentType' => 'text/html; charset=ISO-8859-1' )
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
MediaWiki 1.27 changes to function UserMailer::send() dropped backwards compatibility with previous versions of this function, which had $replyto as the 5th argument and $contentType as the 6th.

As a result SWLEmailer::notifyUser(), when used with MediaWiki 1.27+, sends notification with incorrect MIME type.

In addition, the use on Html::element() to include the description of changes, breaks the HTML formatting, while using Html::rawElement() works correctly.