### PR TITLE
Fix 'retrun' typo

### DIFF
--- a/includes/SWL_PropertyChange.php
+++ b/includes/SWL_PropertyChange.php
@@ -60,7 +60,7 @@ class SWLPropertyChange {
 	}
 
 	/**
-	 * Retruns the old value, or null if there is none.
+	 * Returns the old value, or null if there is none.
 	 *
 	 * @return SMWDataItem or null
 	 */


### PR DESCRIPTION
Fix 'retrun' typo per task T201491 at Wikimedia Phabricator