### PR TITLE
Remove trailing whitespace from system message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -27,7 +27,7 @@
 	"swl-custom-legend": "Custom text",
 	"swl-custom-remove-property": "Remove",
 	"swl-custom-text-add": "Add custom text",
-	"swl-custom-input": "If the property $1 changes its value to $2, notify users with the following text: $3 ",
+	"swl-custom-input": "If the property $1 changes its value to $2, notify users with the following text: $3",
 	"swl-watchlist-position": "Showing the last {{PLURAL:$1|change|'''$1''' changes starting with change '''#$2'''}}:",
 	"swl-watchlist-insertions": "New:",
 	"swl-watchlist-deletions": "Old:",


### PR DESCRIPTION
I am being bold now. There are already many translations without this trailing whitespace so we may as well remove it from the source string. In case this appears to be wrong a follow up pull needs to be done anyways to create a situation where the whitespace is not needed anyways.

[skip ci]

Fixes #95 