### PR TITLE
Avoid usage of deprecated `Hook::run()`

### DIFF
--- a/src/ChangeSet.php
+++ b/src/ChangeSet.php
@@ -1,19 +1,20 @@
 <?php
 
 /**
- * 
- * 
+ *
+ *
  * @since 0.1
- * 
+ *
  * @file ChangeSet.php
  * @ingroup SemanticWatchlist
- * 
+ *
  * @licence GNU GPL v3 or later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 namespace SWL;
 
 use Hooks;
+use MediaWiki\MediaWikiServices;
 use SMWDIProperty;
 use SMWDIWikiPage;
 use SMWDataItem;
@@ -21,67 +22,67 @@ use SMWSemanticData;
 use Title;
 
 class ChangeSet {
-	
+
 	/**
 	 * The subject the changes apply to.
-	 * 
+	 *
 	 * @var SMWDIWikiPage
 	 */
 	private $subject;
-	
+
 	/**
 	 * Object holding semantic data that got inserted.
-	 * 
+	 *
 	 * @var SMWSemanticData
 	 */
 	private $insertions;
-	
+
 	/**
 	 * Object holding semantic data that got deleted.
-	 * 
+	 *
 	 * @var SMWSemanticData
-	 */	
+	 */
 	private $deletions;
-	
+
 	/**
 	 * List of all changes(, not including insertions and deletions).
-	 * 
+	 *
 	 * @var PropertyChanges
 	 */
 	private $changes;
-	
+
 	/**
 	 * DB ID of the change set (swl_sets.set_id).
-	 * 
+	 *
 	 * @var integer
 	 */
 	private $id;
-	
+
 	/**
 	 * The title of the page the changeset holds changes for.
 	 * The title will be constructed from the subject of the SMWChangeSet
 	 * the first time getTitle is called, so it should be accessed via this
 	 * method.
-	 * 
+	 *
 	 * @var Title or false
 	 */
 	private $title = false;
-	
+
 	/**
 	 * The edit this set of changes belongs to.
-	 * 
+	 *
 	 * @var Edit
 	 */
 	private $edit;
-	
+
 	/**
 	 * Creates and returns a new ChangeSet instance from a database result
-	 * obtained by doing a select on swl_sets. 
-	 * 
+	 * obtained by doing a select on swl_sets.
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param $set
-	 * 
+	 *
 	 * @return ChangeSet
 	 */
 	public static function newFromDBResult( $set ) {
@@ -98,9 +99,9 @@ class ChangeSet {
 				$set->edit_id
 			)
 		);
-		
+
 		$dbr = wfGetDb( DB_REPLICA );
-		
+
 		$changes = $dbr->select(
 			'swl_changes',
 			array(
@@ -113,27 +114,27 @@ class ChangeSet {
 				'change_set_id' => $set->spe_set_id
 			)
 		);
-		
+
 		foreach ( $changes as $change ) {
 			$property = SMWDIProperty::doUnserialize( $change->change_property, '__pro' );
-			
+
 			$changeSet->addChange(
 				$property,
 				PropertyChange::newFromSerialization( $property, $change->change_old_value, $change->change_new_value )
 			);
-		}	
-		
+		}
+
 		return $changeSet;
 	}
-	
+
 	/**
 	 * Creates and returns a new ChangeSet instance from a database result
-	 * obtained by doing a select on swl_sets. 
-	 * 
+	 * obtained by doing a select on swl_sets.
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param array $changeSetArray
-	 * 
+	 *
 	 * @return ChangeSet
 	 */
 	public static function newFromArray( array $changeSetArray ) {
@@ -162,58 +163,58 @@ class ChangeSet {
 						array_key_exists( 'old', $change ) ? $change['old'] : null,
 						array_key_exists( 'new', $change ) ? $change['new'] : null
 					)
-				);					
+				);
 			}
-		}		
+		}
 
 		return $changeSet;
 	}
-	
+
 	/**
 	 * Creates and returns a new SMWChangeSet from 2 SMWSemanticData objects.
-	 * 
+	 *
 	 * @param SMWSemanticData $old
 	 * @param SMWSemanticData $new
 	 * @param array $filterProperties Optional list of properties (string serializations) to filter on. Null for no filtering.
-	 * 
+	 *
 	 * @return SMWChangeSet
 	 */
 	public static function newFromSemanticData( SMWSemanticData $old, SMWSemanticData $new, array $filterProperties = null ) {
 		$subject = $old->getSubject();
-		
+
 		if ( $subject != $new->getSubject() ) {
 			return new self( $subject );
 		}
-		
+
 		$changes = new PropertyChanges();
 		$insertions = new SMWSemanticData( $subject );
 		$deletions = new SMWSemanticData( $subject );
-		
+
 		$oldProperties = array();
 		$newProperties = array();
-		
+
 		foreach ( $old->getProperties() as $property ) {
 			if ( is_null( $filterProperties ) || in_array( $property->getLabel(), $filterProperties ) ) {
 				$oldProperties[] = $property;
 			}
 		}
-		
+
 		foreach ( $new->getProperties() as $property ) {
 			if ( is_null( $filterProperties ) || in_array( $property->getLabel(), $filterProperties ) ) {
 				$newProperties[] = $property;
 			}
 		}
-		
+
 		// Find the deletions.
 		self::findSingleDirectionChanges( $deletions, $oldProperties, $old, $newProperties, $filterProperties );
-		
+
 		// Find the insertions.
 		self::findSingleDirectionChanges( $insertions, $newProperties, $new, $oldProperties, $filterProperties );
-		
+
 		foreach ( $oldProperties as $propertyKey => /* SMWDIProperty */ $diProperty ) {
 			$oldDataItems = array();
 			$newDataItems = array();
-			
+
 			// Populate the data item arrays using keys that are their hash, so matches can be found.
 			// Note: this code assumes there are no duplicates.
 			foreach ( $old->getPropertyValues( $diProperty ) as /* SMWDataItem */ $dataItem ) {
@@ -221,52 +222,52 @@ class ChangeSet {
 			}
 			foreach ( $new->getPropertyValues( $diProperty ) as /* SMWDataItem */ $dataItem ) {
 				$newDataItems[$dataItem->getHash()] = $dataItem;
-			}			
-			
+			}
+
 			$foundMatches = array();
-			
+
 			// Find values that are both in the old and new version.
 			foreach ( array_keys( $oldDataItems ) as $hash ) {
 				if ( array_key_exists( $hash, $newDataItems ) ) {
 					$foundMatches[] = $hash;
 				}
 			}
-			
+
 			// Remove the values occuring in both sets, so only changes remain.
 			foreach ( $foundMatches as $foundMatch ) {
 				unset( $oldDataItems[$foundMatch] );
 				unset( $newDataItems[$foundMatch] );
 			}
-			
+
 			// Find which group is biggest, so it's easy to loop over all values of the smallest.
 			$oldIsBigger = count( $oldDataItems ) > count ( $newDataItems );
 			$bigGroup = $oldIsBigger ? $oldDataItems : $newDataItems;
 			$smallGroup = $oldIsBigger ? $newDataItems : $oldDataItems;
-			
+
 			// Add all one-to-one changes.
 			while ( $dataItem = array_shift( $smallGroup ) ) {
 				$changes->addPropertyObjectChange( $diProperty, new PropertyChange( $dataItem, array_shift( $bigGroup ) ) );
 			}
-			
+
 			// If the bigger group is not-equal to the smaller one, items will be left,
 			// that are either insertions or deletions, depending on the group.
 			if ( count( $bigGroup ) > 0 ) {
 				$semanticData = $oldIsBigger ? $deletions : $insertions;
-				
+
 				foreach ( $bigGroup as /* SMWDataItem */ $dataItem ) {
 					$semanticData->addPropertyObjectValue( $diProperty, $dataItem );
-				}				
+				}
 			}
 		}
-		
+
 		return new self( $subject, $changes, $insertions, $deletions );
 	}
-	
+
 	/**
 	 * Finds the inserts or deletions and adds them to the passed SMWSemanticData object.
 	 * These values will also be removed from the first list of properties and their values,
-	 * so it can be used for one-to-one change finding later on.  
-	 * 
+	 * so it can be used for one-to-one change finding later on.
+	 *
 	 * @param SMWSemanticData $changeSet
 	 * @param array $oldProperties
 	 * @param SMWSemanticData $oldData
@@ -274,9 +275,9 @@ class ChangeSet {
 	 */
 	private static function findSingleDirectionChanges( SMWSemanticData &$changeSet,
 		array &$oldProperties, SMWSemanticData $oldData, array $newProperties ) {
-		
+
 		$deletionKeys = array();
-		
+
 		foreach ( $oldProperties as $propertyKey => /* SMWDIProperty */ $diProperty ) {
 			if ( !array_key_exists( $propertyKey, $newProperties ) ) {
 				foreach ( $oldData->getPropertyValues( $diProperty ) as /* SMWDataItem */ $dataItem ) {
@@ -285,15 +286,15 @@ class ChangeSet {
 				$deletionKeys[] = $propertyKey;
 			}
 		}
-		
+
 		foreach ( $deletionKeys as $key ) {
 			unset( $oldProperties[$propertyKey] );
 		}
 	}
-	
+
 	/**
 	 * Create a new instance of a change set.
-	 * 
+	 *
 	 * @param SMWDIWikiPage $subject
 	 * @param PropertyChanges $changes Can be null
 	 * @param SMWSemanticData $insertions Can be null
@@ -304,28 +305,28 @@ class ChangeSet {
 	public function __construct( SMWDIWikiPage $subject, /* PropertyChanges */ $changes = null,
 		/* SMWSemanticData */ $insertions = null, /* SMWSemanticData */ $deletions = null,
 		$id = null, /* Edit */ $edit = null ) {
-	
+
 		$this->subject = $subject;
 		$this->changes = is_null( $changes ) ? new PropertyChanges() : $changes;
 		$this->insertions = is_null( $insertions ) ? new SMWSemanticData( $subject ): $insertions;
 		$this->deletions = is_null( $deletions ) ? new SMWSemanticData( $subject ): $deletions;
-		
+
 		$this->id = $id;
 		$this->edit = $edit;
 	}
-	
+
 	/**
 	 * Rteurns if the change set contains (changes for) user defined properties.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function hasUserDefinedProperties() {
 		$properties = array();
-		
+
 		$allProps = $this->getAllProperties();
-		
+
 		wfDebugLog(
 			'SemanticWatchlist',
 			'Checking {count} properties for any that are user defined',
@@ -336,7 +337,7 @@ class ChangeSet {
 		);
 		foreach ( $allProps as /* SMWDIProperty */ $property ) {
 			$userDefined = $property->isUserDefined();
-			
+
 			wfDebugLog(
 				'SemanticWatchlist',
 				'Property {pname} is user defined: {udef}',
@@ -350,15 +351,15 @@ class ChangeSet {
 				$properties[] = $property;
 			}
 		}
-		
+
 		return count( $properties ) != 0;
 	}
-	
+
 	/**
 	 * Returns whether the set contains any changes.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function hasChanges() {
@@ -366,48 +367,48 @@ class ChangeSet {
 			|| $this->insertions->hasVisibleProperties()
 			|| $this->deletions->hasVisibleProperties();
 	}
-	
+
 	/**
 	 * Returns a SMWSemanticData object holding all inserted SMWDataItem objects.
-	 * 
+	 *
 	 * @return SMWSemanticData
 	 */
 	public function getInsertions() {
 		return $this->insertions;
 	}
-	
+
 	/**
 	 * Returns a SMWSemanticData object holding all deleted SMWDataItem objects.
-	 * 
+	 *
 	 * @return SMWSemanticData
 	 */
 	public function getDeletions() {
 		return $this->deletions;
 	}
-	
+
 	/**
 	 * Returns a PropertyChanges object holding all PropertyChange objects.
-	 * 
+	 *
 	 * @return PropertyChanges
-	 */	
+	 */
 	public function getChanges() {
 		return $this->changes;
 	}
-	
+
 	/**
 	 * Returns the subject these changes apply to.
-	 * 
+	 *
 	 * @return SMWDIWikiPage
 	 */
 	public function getSubject() {
-		return $this->subject;		
+		return $this->subject;
 	}
-	
+
 	/**
 	 * Adds a PropertyChange to the set for the specified SMWDIProperty.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param SMWDIProperty $property
 	 * @param PropertyChange $change
 	 */
@@ -424,34 +425,34 @@ class ChangeSet {
 				break;
 		}
 	}
-	
+
 	/**
 	 * Adds a SMWDataItem representing an insertion to the set for the specified SMWDIProperty.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param SMWDIProperty $property
 	 * @param SMWDataItem $dataItem
 	 */
 	public function addInsertion( SMWDIProperty $property, SMWDataItem $dataItem ) {
 		$this->insertions->addPropertyObjectValue( $property, $dataItem );
 	}
-	
+
 	/**
 	 * Adds a SMWDataItem representing a deletion to the set for the specified SMWDIProperty.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param SMWDIProperty $property
 	 * @param SMWDataItem $dataItem
 	 */
 	public function addDeletion( SMWDIProperty $property, SMWDataItem $dataItem ) {
 		$this->deletions->addPropertyObjectValue( $property, $dataItem );
 	}
-	
+
 	/**
 	 * Returns a list of all properties.
-	 * 
+	 *
 	 * @return array of SMWDIProperty
 	 */
 	public function getAllProperties() {
@@ -461,10 +462,10 @@ class ChangeSet {
 			$this->getDeletions()->getProperties()
 		);
 	}
-	
+
 	/**
 	 * Removes all changes for a certian property.
-	 * 
+	 *
 	 * @param SMWDIProperty $property
 	 */
 	public function removeChangesForProperty( SMWDIProperty $property ) {
@@ -472,38 +473,38 @@ class ChangeSet {
 		$this->getInsertions()->removeDataForProperty( $property );
 		$this->getDeletions()->removeDataForProperty( $property );
 	}
-	
+
 	/**
 	 * Returns a list of ALL changes, including isertions and deletions.
-	 * 
+	 *
 	 * @param SMWDIProperty $property
-	 * 
+	 *
 	 * @return array of PropertyChange
 	 */
 	public function getAllPropertyChanges( SMWDIProperty $property ) {
 		$changes = array();
-		
+
 		foreach ( $this->changes->getPropertyChanges( $property ) as /* PropertyChange */ $change ) {
 			$changes[] = $change;
 		}
-		
+
 		foreach ( $this->insertions->getPropertyValues( $property ) as /* SMWDataItem */ $dataItem ) {
 			$changes[] = new PropertyChange( null, $dataItem );
 		}
 
 		foreach ( $this->deletions->getPropertyValues( $property ) as /* SMWDataItem */ $dataItem ) {
 			$changes[] = new PropertyChange( $dataItem, null );
-		}			
-		
+		}
+
 		return $changes;
 	}
-	
+
 	/**
 	 * Serializes the object as an associative array, which can be passed
 	 * to newFromArray to create a new instance.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @return array
 	 */
 	public function toArray() {
@@ -515,56 +516,57 @@ class ChangeSet {
  			'editid' => $this->edit->getId(),
  			'changes' => array()
 		);
-		
+
 		foreach ( $this->getAllProperties() as /* SMWDIProperty */ $property ) {
 			$propChanges = array();
-			
+
 			foreach ( $this->getAllPropertyChanges( $property ) as /* PropertyChange */ $change ) {
 				$propChange = array();
-				
+
 				if ( is_object( $change->getOldValue() ) ) {
 					$propChange['old'] = $change->getOldValue()->getSerialization();
 				}
-				
+
 				if ( is_object( $change->getNewValue() ) ) {
 					$propChange['new'] = $change->getNewValue()->getSerialization();
 				}
 
 				$propChanges[] = $propChange;
 			}
-			
+
 			$changeSet['changes'][$property->getSerialization()] = $propChanges;
 		}
-		
+
 		return $changeSet;
 	}
-	
+
 	/**
 	 * Save the change set to the database.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param array of Group
 	 * @param integer $editId
-	 * 
+	 *
 	 * @return integer ID of the inserted row (0 if nothing was inserted).
 	 */
 	public function writeToStore( array $groupsToAssociate, $editId ) {
 		if ( !$this->hasUserDefinedProperties() ) {
 			return 0;
 		}
-		
-		Hooks::run( 'SWLBeforeChangeSetInsert', array( &$this, &$groupsToAssociate, &$editId ) );
-		
+
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		$hookContainer->run( 'SWLBeforeChangeSetInsert', array( &$this, &$groupsToAssociate, &$editId ) );
+
 		$dbw = wfGetDB( DB_MASTER );
-		
+
 		$dbw->insert(
 			'swl_sets',
 			array( 'set_id' => null )
 		);
-		
+
 		$id = $dbw->insertId();
-		
+
 		$dbw->insert(
 			'swl_sets_per_edit',
 			array(
@@ -572,13 +574,13 @@ class ChangeSet {
 				'spe_edit_id' => $editId
 			)
 		);
-		
+
 		$changes = array();
-		
+
 		foreach ( $this->getAllProperties() as /* SMWDIProperty */ $property ) {
 			if ( $property->isUserDefined() ) {
 				$propSerialization = $property->getSerialization();
-			
+
 				foreach ( $this->getChanges()->getPropertyChanges( $property ) as /* PropertyChange */ $change ) {
 					$changes[] = array(
 						'property' => $propSerialization,
@@ -601,12 +603,12 @@ class ChangeSet {
 						'old' => $dataItem->getSerialization(),
 						'new' => null
 					);
-				}				
+				}
 			}
 		}
-		
+
 		$dbw->startAtomic( __METHOD__ );
-		
+
 		foreach ( $changes as $change ) {
 			if ( $change['property'] == '' ) {
 				// When removing the last value for a property of a page,
@@ -614,7 +616,7 @@ class ChangeSet {
 				// name, so skip that. Better to fix higher up though.
 				continue;
 			}
-			
+
 			$dbw->insert(
 				'swl_changes',
 				array(
@@ -623,9 +625,9 @@ class ChangeSet {
 					'change_old_value' => $change['old'],
 					'change_new_value' => $change['new']
 				)
-			);			
+			);
 		}
-		
+
 		foreach ( $groupsToAssociate as /* Group */ $group ) {
 			$dbw->insert(
 				'swl_sets_per_group',
@@ -635,127 +637,127 @@ class ChangeSet {
 				)
 			);
 		}
-		
+
 		$dbw->endAtomic( __METHOD__ );
-		
-		Hooks::run( 'SWLAfterChangeSetInsert', array( &$this, $groupsToAssociate, $editId ) );
-		
+
+		$hookContainer->run( 'SWLAfterChangeSetInsert', array( &$this, $groupsToAssociate, $editId ) );
+
 		return $id;
 	}
-	
+
 	/**
 	 * Gets the title of the page these changes belong to.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @return Title
 	 */
 	public function getTitle() {
 		if ( $this->title === false ) {
 			$this->title = Title::makeTitle( $this->getSubject()->getNamespace(), $this->getSubject()->getDBkey() );
 		}
-		
+
 		return $this->title;
 	}
-	
+
 	/**
 	 * Gets the edit this set of changes belong to.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @return Edit
 	 */
 	public function getEdit() {
 		return $this->edit;
 	}
-	
+
 	/**
 	 * Sets the edit this set of changes belong to.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param Edit $edit
 	 */
 	public function setEdit( Edit $edit ) {
 		$this->edit = $edit;
 	}
-	
+
 	/**
 	 * Returns if a certain insertion is present in the set of changes.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param SMWDIProperty $property
 	 * @param string $value
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function hasInsertion( SMWDIProperty $property, $value ) {
 		$has = false;
-		
+
 		foreach ( $this->insertions->getPropertyValues( $property ) as /* SMWDataItem */ $insertion ) {
 			if ( $insertion->getSerialization() == $value ) {
 				$has = true;
 				break;
 			}
 		}
-		
+
 		return $has;
 	}
-	
+
 	/**
 	 * Returns if a certain insertion is present in the set of changes.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param SMWDIProperty $property
 	 * @param string $value
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function hasDeletion( SMWDIProperty $property, $value ) {
 		$has = false;
-		
+
 		foreach ( $this->deletions->getPropertyValues( $property ) as /* SMWDataItem */ $deletion ) {
 			if ( $deletion->getSerialization() == $value ) {
 				$has = true;
 				break;
 			}
 		}
-		
-		return $has;		
+
+		return $has;
 	}
-	
+
 	/**
 	 * Returns if a certain change is present in the set of changes.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param SMWDIProperty $property
 	 * @param PropertyChange $change
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function hasChange( SMWDIProperty $property, PropertyChange $change ) {
 		$has = false;
-		
+
 		foreach ( $this->changes->getPropertyChanges( $property ) as /* PropertyChange */ $propChange ) {
 			if ( $propChange->getSerialization() == $change->getSerialization() ) {
 				$has = true;
 				break;
 			}
 		}
-		
-		return $has;			
+
+		return $has;
 	}
-	
+
 	/**
 	 * Merges in the changes of another change set.
 	 * Duplicate changes are detected and only kept as a single change.
 	 * This is usefull for merging sets with (possibly overlapping) changes belonging to a single edit.
-	 * 
+	 *
 	 * @since 0.1
-	 * 
+	 *
 	 * @param ChangeSet $set
 	 */
 	public function mergeInChangeSet( ChangeSet $set ) {
@@ -765,19 +767,19 @@ class ChangeSet {
 					$this->addChange( $property, $change );
 				}
 			}
-			
+
 			foreach ( $set->getInsertions()->getPropertyValues( $property ) as /* SMWDataItem */ $dataItem ) {
 				if ( !$this->hasInsertion( $property, $dataItem ) ) {
 					$this->addInsertion( $property, $dataItem );
 				}
 			}
-	
+
 			foreach ( $set->getDeletions()->getPropertyValues( $property ) as /* SMWDataItem */ $dataItem ) {
 				if ( !$this->hasInsertion( $property, $dataItem ) ) {
 					$this->addDeletion( $property, $dataItem );
 				}
-			}		
+			}
 		}
 	}
-	
+
 }

--- a/src/Edit.php
+++ b/src/Edit.php
@@ -14,6 +14,7 @@
 namespace SWL;
 
 use Hooks;
+use MediaWiki\MediaWikiServices;
 use Title;
 use User;
 
@@ -154,7 +155,8 @@ class Edit {
 	 * @return boolean Success indicator
 	 */
 	private function insertIntoDB() {
-		Hooks::run( 'SWLBeforeEditInsert', array( &$this ) );
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		$hookContainer->run( 'SWLBeforeEditInsert', array( &$this ) );
 
 		$dbr = wfGetDB( DB_MASTER );
 
@@ -169,7 +171,7 @@ class Edit {
 
 		$this->id = $dbr->insertId();
 
-		Hooks::run( 'SWLAfterEditInsert', array( &$this ) );
+		$hookContainer->run( 'SWLAfterEditInsert', array( &$this ) );
 
 		return $result;
 	}

--- a/src/Emailer.php
+++ b/src/Emailer.php
@@ -15,6 +15,7 @@ namespace SWL;
 
 use Html;
 use Hooks;
+use MediaWiki\MediaWikiServices;
 use SpecialPage;
 use User;
 use UserMailer;
@@ -60,7 +61,8 @@ final class Emailer {
 
 		$title = wfMessage( 'swl-email-propschanged', array( $changeSet->getEdit()->getTitle()->getFullText() ) )->text();
 
-		Hooks::run( 'SWLBeforeEmailNotify', array( $group, $user, $changeSet, $describeChanges, &$title, &$emailText ) );
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		$hookContainer->run( 'SWLBeforeEmailNotify', array( $group, $user, $changeSet, $describeChanges, &$title, &$emailText ) );
 
 		return UserMailer::send(
 			new MailAddress( $user ),

--- a/src/Group.php
+++ b/src/Group.php
@@ -530,7 +530,8 @@ class Group {
 		$users = $this->getWatchingUsers();
 
 		if ( $changes->hasChanges( true ) ) {
-			Hooks::run( 'SWLGroupNotify', array( $this, $users, $changes ) );
+			MediaWikiServices::getInstance()->getHookContainer()
+				->run( 'SWLGroupNotify', array( $this, $users, $changes ) );
 		}
 	}
 


### PR DESCRIPTION
NOTE: cosmetic changes automatically applied by my IDE (PHPStorm) styling rules. I didn't do them by hand but I think they're valid though since they remove unnecessary trailing spaces and tabs.