### PR TITLE
Fix prefs and email

### DIFF
--- a/src/Emailer.php
+++ b/src/Emailer.php
@@ -65,11 +65,11 @@ final class Emailer {
 		$hookContainer->run( 'SWLBeforeEmailNotify', array( $group, $user, $changeSet, $describeChanges, &$title, &$emailText ) );
 
 		return UserMailer::send(
-			new MailAddress( $user ),
+			MailAddress::newFromUser( $user ),
 			new MailAddress( $wgPasswordSender, $wgPasswordSenderName ),
 			$title,
 			$emailText,
-			array( 'contentType' => 'text/html; charset=ISO-8859-1' )
+			array( 'contentType' => 'text/html; charset=UTF-8' )
 		);
 	}
 

--- a/src/MediaWiki/Hooks/GetPreferences.php
+++ b/src/MediaWiki/Hooks/GetPreferences.php
@@ -115,10 +115,10 @@ class GetPreferences {
 		}
 
 		foreach ( $properties as &$property ) {
-			$property = "''$property''";
+			$property = "''" . wfEscapeWikiText( $property ) . "''";
 		}
 
-		$this->preferences['swl_watchgroup_' . $group->getId()] = $this->addGoupPreference(
+		$this->preferences['swl_watchgroup_' . $group->getId()] = $this->addGroupPreference(
 			$type,
 			$group->getName(),
 			$name,
@@ -150,16 +150,16 @@ class GetPreferences {
 	 * @search swl-prefs-category-label, swl-prefs-namespace-label,
 	 * swl-prefs-concept-label
 	 */
-	protected function addGoupPreference( $type, $group, $name, $properties ) {
+	protected function addGroupPreference( $type, $group, $name, $properties ) {
 		return  array(
 			'type' => 'toggle',
-			'label' => wfMessage(
+			'label-message' => wfMessage(
 				"swl-prefs-$type-label",
-				$group,
+				wfEscapeWikiText( $group ),
 				count( $properties ),
 				$this->language->listToText( $properties ),
-				$name
-			)->inLanguage( $this->language )->text(),
+				wfEscapeWikiText( $name )
+			),
 			'section' => 'swl/swlgroup',
 		);
 	}


### PR DESCRIPTION
Fix html display of groups on Special:Preferences and fix email sending

Previously the groups on Special:Preferences were displayed incorrectly as
the default i18n message used wikitext but it was being set as plain text.

Previously emails were being sent to wikiusername@localhost instead of the
user's actual email.