### PR TITLE
SemanticWatchlist: display namespace of titles

### DIFF
--- a/src/Special/Watchlist.php
+++ b/src/Special/Watchlist.php
@@ -345,7 +345,7 @@ class Watchlist extends SpecialPage {
 				Html::element(
 					'a',
 					array( 'href' => $edit->getTitle()->getLocalURL() ),
-					$edit->getTitle()->getText()
+					$edit->getTitle()->getPrefixedText()
 				) . ' (' .
 				Html::element(
 					'a',


### PR DESCRIPTION
Use Title::getPrefixedText() instead of Title::getText()