### PR TITLE
i18n: define message `semanticwatchlist-title`

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,9 +1,11 @@
 {
 	"@metadata": {
 		"authors": [
-			"Jeroen De Dauw"
+			"Jeroen De Dauw",
+			"Daniel Scherzer"
 		]
 	},
+	"semanticwatchlist-title": "SemanticWatchlist",
 	"semanticwatchlist-desc": "Lets users be notified of specific changes to Semantic MediaWiki data",
 	"right-semanticwatch": "Use semantic watchlist",
 	"right-semanticwatchgroups": "[[Special:WatchlistConditions|Modify]] the semantic watchlist groups",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -9,9 +9,11 @@
 			"Shirayuki",
 			"Siebrand",
 			"Umherirrender",
-			"아라"
+			"아라",
+			"Daniel Scherzer"
 		]
 	},
+	"semanticwatchlist-title": "Extension name on [[Special:Version]]",
 	"semanticwatchlist-desc": "{{desc|name=Semantic Watchlist|url=https://www.mediawiki.org/wiki/Extension:SemanticWatchlist}}",
 	"right-semanticwatch": "{{doc-right|semanticwatch}}",
 	"right-semanticwatchgroups": "{{doc-right|semanticwatchgroups}}",


### PR DESCRIPTION
Used as the extension name on Special:Version, without defining the message the name of the extension shows up as `⧼semanticwatchlist-title⧽`, i.e. the underlying message key.

METHW-111