### PR TITLE
i18n: define missing `action-*` messages

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,12 +1,15 @@
 {
 	"@metadata": {
 		"authors": [
-			"Jeroen De Dauw"
+			"Jeroen De Dauw",
+			"Daniel Scherzer"
 		]
 	},
 	"semanticwatchlist-desc": "Lets users be notified of specific changes to Semantic MediaWiki data",
 	"right-semanticwatch": "Use semantic watchlist",
+	"action-semanticwatch": "use semantic watchlist",
 	"right-semanticwatchgroups": "[[Special:WatchlistConditions|Modify]] the semantic watchlist groups",
+	"action-semanticwatchgroups": "modify the semantic watchlist groups",
 	"special-semanticwatchlist": "Semantic Watchlist",
 	"special-watchlistconditions": "Semantic watchlist conditions",
 	"swl-group-name": "Group name:",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -9,12 +9,15 @@
 			"Shirayuki",
 			"Siebrand",
 			"Umherirrender",
-			"아라"
+			"아라",
+			"Daniel Scherzer"
 		]
 	},
 	"semanticwatchlist-desc": "{{desc|name=Semantic Watchlist|url=https://www.mediawiki.org/wiki/Extension:SemanticWatchlist}}",
 	"right-semanticwatch": "{{doc-right|semanticwatch}}",
+	"action-semanticwatch": "{{doc-action|semanticwatch}}",
 	"right-semanticwatchgroups": "{{doc-right|semanticwatchgroups}}",
+	"action-semanticwatchgroups": "{{doc-action|semanticwatchgroups}}",
 	"special-semanticwatchlist": "{{doc-special|SemanticWatchlist}}",
 	"special-watchlistconditions": "{{doc-special|WatchlistConditions}}",
 	"swl-group-name": "This is the title of the field that lets you specify the name of a group of properties to be watched on [[Special:SemanticWatchlist]].\n{{Identical|Group name}}",


### PR DESCRIPTION
Add messages `action-semanticwatch` and `action-semanticwatchgroups`, which are used to display error messages on Special:SemanticWatchlist and Special:WatchlistConditions respectively when the viewer does not have the rights needed to access the pages.

Note that unlike `right-semanticwatchgroups`, the action message does not include a link to the special page, since it is shown while on the special page.

METHW-112