### PR TITLE
Replace DB_MASTER with DB_PRIMARY

### DIFF
--- a/src/Api/DeleteWatchlistGroup.php
+++ b/src/Api/DeleteWatchlistGroup.php
@@ -142,7 +142,7 @@ class DeleteWatchlistGroup extends ApiBase {
 			}
 		}
 
-		$dbw = wfGetDB( DB_MASTER );
+		$dbw = wfGetDB( DB_PRIMARY );
 		$dbw->startAtomic( __METHOD__ );
 
 		// Delete all edits and sets per edits only linked to this group.

--- a/src/ChangeSet.php
+++ b/src/ChangeSet.php
@@ -558,7 +558,7 @@ class ChangeSet {
 		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		$hookContainer->run( 'SWLBeforeChangeSetInsert', array( &$this, &$groupsToAssociate, &$editId ) );
 
-		$dbw = wfGetDB( DB_MASTER );
+		$dbw = wfGetDB( DB_PRIMARY );
 
 		$dbw->insert(
 			'swl_sets',

--- a/src/Edit.php
+++ b/src/Edit.php
@@ -134,7 +134,7 @@ class Edit {
 	 * @return boolean Success indicator
 	 */
 	private function updateInDB() {
-		$dbr = wfGetDB( DB_MASTER );
+		$dbr = wfGetDB( DB_PRIMARY );
 
 		return  $dbr->update(
 			'swl_edits',
@@ -158,7 +158,7 @@ class Edit {
 		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		$hookContainer->run( 'SWLBeforeEditInsert', array( &$this ) );
 
-		$dbr = wfGetDB( DB_MASTER );
+		$dbr = wfGetDB( DB_PRIMARY );
 
 		$result = $dbr->insert(
 			'swl_edits',

--- a/src/Group.php
+++ b/src/Group.php
@@ -186,7 +186,7 @@ class Group {
 	 * @return boolean Success indicator
 	 */
 	private function updateInDB() {
-		$dbr = wfGetDB( DB_MASTER );
+		$dbr = wfGetDB( DB_PRIMARY );
 		return  $dbr->update(
 			'swl_groups',
 			array(
@@ -209,7 +209,7 @@ class Group {
 	 * @return boolean Success indicator
 	 */
 	private function insertIntoDB() {
-		$dbr = wfGetDB( DB_MASTER );
+		$dbr = wfGetDB( DB_PRIMARY );
 
 		$result = $dbr->insert(
 			'swl_groups',

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -45,7 +45,7 @@ class HookRegistry {
 		$configuration = $this->configuration;
 
 		$tableUpdater = new TableUpdater(
-			new LazyDBConnectionProvider( DB_MASTER )
+			new LazyDBConnectionProvider( DB_PRIMARY )
 		);
 
 		/**


### PR DESCRIPTION
DB_MASTER was deprecated in MediaWiki 1.36 and removed in MediaWiki 1.43