### PR TITLE
Add CSRF protection for mutable APIs

### DIFF
--- a/module/jquery.watchlistcondition.js
+++ b/module/jquery.watchlistcondition.js
@@ -173,8 +173,7 @@
 		args[self.find('select :selected').attr('type')] = self.find( '.conditionInput' ).val();
 
 		var api = new mw.Api();
-		// TODO make POST
-		return api.get( args ).then(
+		return api.postWithEditToken( args ).then(
 			function (data) {
 				return data.success;
 			},
@@ -186,8 +185,7 @@
 
 	this.doDelete = function( callback ) {
 		var api = new mw.Api();
-		// TODO make POST
-		return api.get( {
+		return api.postWithEditToken( {
 			'action': 'deleteswlgroup',
 			'format': 'json',
 			'formatversion': 2,

--- a/src/Api/AddWatchlistGroup.php
+++ b/src/Api/AddWatchlistGroup.php
@@ -18,14 +18,14 @@ use ApiBase;
 use SWL\Group;
 
 class AddWatchlistGroup extends ApiBase {
-	
+
 	public function __construct( $main, $action ) {
 		parent::__construct( $main, $action );
 	}
-	
+
 	public function execute() {
 		$user = $this->getUser();
-		
+
 		if ( !$user->isAllowed( 'semanticwatchgroups' ) ) {
 			$this->dieWithError( [
 				'apierror-permissiondenied',
@@ -36,7 +36,7 @@ class AddWatchlistGroup extends ApiBase {
 		if ( $block ) {
 			$this->dieBlocked( $block );
 		}
-		
+
 		$params = $this->extractRequestParams();
 		$params['customTexts'] = Group::unserializedCustomTexts( $params['customTexts'] );
 
@@ -49,19 +49,19 @@ class AddWatchlistGroup extends ApiBase {
 			$params['concepts'],
 			$params['customTexts']
 		);
-		
+
 		$this->getResult()->addValue(
 			null,
 			'success',
 			$group->writeToDB()
 		);
-		
+
 		$this->getResult()->addValue(
 			'group',
 			'id',
 			$group->getId()
 		);
-		
+
 		$this->getResult()->addValue(
 			'group',
 			'name',
@@ -102,7 +102,7 @@ class AddWatchlistGroup extends ApiBase {
 			),
 		);
 	}
-	
+
 	public function getParamDescription() {
 		return array(
 			'name' => 'The name of the group, used for display in the user preferences',
@@ -113,7 +113,7 @@ class AddWatchlistGroup extends ApiBase {
 			'customTexts' => 'Custom Text to be sent in Emails',
 		);
 	}
-	
+
 	public function getDescription() {
 		return array(
 			'API module to add semantic watchlist groups.'
@@ -125,10 +125,18 @@ class AddWatchlistGroup extends ApiBase {
 			'api.php?action=addswlgroup&name=My group of awesome&properties=Has awesomeness|Has epicness&categories=Awesome stuff',
 			'api.php?action=addswlgroup&name=My group of awesome&properties=Has awesomeness|Has epicness&categories=Awesome stuff&customTexts=Has awesomeness~true~Changed to awesome now',
 		);
-	}	
-	
+	}
+
+	public function needsToken() {
+		return 'csrf';
+	}
+
+	public function isWriteMode() {
+		return true;
+	}
+
 	public function getVersion() {
 		return __CLASS__ . ': $Id$';
-	}		
-	
+	}
+
 }

--- a/src/Api/DeleteWatchlistGroup.php
+++ b/src/Api/DeleteWatchlistGroup.php
@@ -26,7 +26,7 @@ class DeleteWatchlistGroup extends ApiBase {
 
 	public function execute() {
 		$user = $this->getUser();
-		
+
 		if ( !$user->isAllowed( 'semanticwatchgroups' ) ) {
 			$this->dieWithError( [
 				'apierror-permissiondenied',
@@ -226,6 +226,14 @@ class DeleteWatchlistGroup extends ApiBase {
 		return array(
 			'api.php?action=deleteswlgroup&ids=42|34',
 		);
+	}
+
+	public function needsToken() {
+		return 'csrf';
+	}
+
+	public function isWriteMode() {
+		return true;
 	}
 
 	public function getVersion() {

--- a/src/Api/EditWatchlistGroup.php
+++ b/src/Api/EditWatchlistGroup.php
@@ -25,7 +25,7 @@ class EditWatchlistGroup extends ApiBase {
 
 	public function execute() {
 		$user = $this->getUser();
-		
+
 		if ( !$user->isAllowed( 'semanticwatchgroups' ) ) {
 			$this->dieWithError( [
 				'apierror-permissiondenied',
@@ -117,6 +117,14 @@ class EditWatchlistGroup extends ApiBase {
 			'api.php?action=editswlgroup&id=42&name=My group of awesome&properties=Has awesomeness|Has epicness&categories=Awesome stuff',
 			'api.php?action=editswlgroup&id=42&name=My group of awesome&properties=Has awesomeness|Has epicness&categories=Awesome stuff&customTexts=Has awesomeness~true~Changed to awesome now',
 		);
+	}
+
+	public function needsToken() {
+		return 'csrf';
+	}
+
+	public function isWriteMode() {
+		return true;
 	}
 
 	public function getVersion() {


### PR DESCRIPTION
Require and send CSRF tokens on all write requests, as well as requiring POST requests.

Essentially, someone could be tricked into clicking a link that could change their watchlist, which is a security issue, though minor considering the scope of this extension.

Please test to make sure that I haven't missed anything in writing this.