### PR TITLE
Watchlist: silence DBPerformance alerts about writes

### DIFF
--- a/src/Special/Watchlist.php
+++ b/src/Special/Watchlist.php
@@ -18,6 +18,7 @@ use FauxRequest;
 use SWL\ChangeSet;
 use HTML;
 use MediaWiki\MediaWikiServices;
+use Profiler;
 use SpecialPage;
 use SMWOutputs;
 use SMWDataValueFactory;
@@ -84,6 +85,10 @@ class Watchlist extends SpecialPage {
 			$this->displayRestrictionError();
 			return;
 		}
+
+		// TODO: refactor this page to not make writes on GET requests; for now,
+		// silencing the performance alerts
+		Profiler::instance()->getTransactionProfiler()->resetExpectations();
 
 		$this->registerUserView( $user );
 


### PR DESCRIPTION
Until this page gets a proper reimplementation that avoids making writes on a GET request, the writes are just clogging up the logs. Silence them by resetting the profiler's expectations.

METHW-206