### PR TITLE
DeleteWatchlistGroup: fix numRows() method call

### DIFF
--- a/src/Api/DeleteWatchlistGroup.php
+++ b/src/Api/DeleteWatchlistGroup.php
@@ -137,7 +137,7 @@ class DeleteWatchlistGroup extends ApiBase {
 				)
 			);
 
-			if ( $dbr->numRows( $groupsForEdit ) < 2 ) {
+			if ( $groupsForEdit->numRows() < 2 ) {
 				$editsToDelete[] = $edit->spe_edit_id;
 			}
 		}


### PR DESCRIPTION
Method was removed from the database class, call the ResultWrapper method

See [T286694](https://phabricator.wikimedia.org/T286694) for context