### PR TITLE
Add CI for MW 1.44-1.45 and remove MW 1.39-1.42

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,39 +17,32 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.39'
-            smw_version: 5.1.0
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:10"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.40'
-            smw_version: 5.1.0
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:10"
-            coverage: true
-            experimental: false
-          - mediawiki_version: '1.41'
-            smw_version: 5.1.0
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:10"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.42'
-            smw_version: 5.1.0
-            php_version: 8.1
+          - mediawiki_version: '1.43'
+            smw_version: dev-master
+            php_version: 8.2
             database_type: mysql
             database_image: "mariadb:10"
             coverage: false
             experimental: false
           - mediawiki_version: '1.43'
             smw_version: dev-master
-            php_version: 8.1
+            php_version: 8.2
             database_type: mysql
             database_image: "mariadb:10"
+            coverage: true
+            experimental: false
+          - mediawiki_version: '1.44'
+            smw_version: dev-master
+            php_version: 8.3
+            database_type: mysql
+            database_image: "mariadb:11"
+            coverage: true
+            experimental: false
+          - mediawiki_version: '1.45'
+            smw_version: dev-master
+            php_version: 8.4
+            database_type: mysql
+            database_image: "mariadb:11"
             coverage: false
             experimental: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             php_version: 8.3
             database_type: mysql
             database_image: "mariadb:11"
-            coverage: true
+            coverage: false
             experimental: false
           - mediawiki_version: '1.45'
             smw_version: dev-master

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"source": "https://github.com/SemanticMediaWiki/SemanticWatchlist"
 	},
 	"require": {
-		"php": ">=7.4",
+		"php": ">=8.2",
 		"composer/installers": ">=1.0.1"
 	},
 	"require-dev": {

--- a/extension.json
+++ b/extension.json
@@ -13,7 +13,7 @@
 	"license-name": "GPL-3.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.39"
+		"MediaWiki": ">= 1.43"
 	},
 	"MessagesDirs": {
 		"SemanticWatchlist": [

--- a/src/Api/QuerySemanticWatchlist.php
+++ b/src/Api/QuerySemanticWatchlist.php
@@ -16,8 +16,8 @@ namespace SWL\Api;
 
 use ApiBase;
 use ApiQueryBase;
+use MediaWiki\Title\Title;
 use SWL\ChangeSet;
-use Title;
 
 class QuerySemanticWatchlist extends ApiQueryBase {
 	public function __construct( $main, $action ) {

--- a/src/ChangeSet.php
+++ b/src/ChangeSet.php
@@ -13,13 +13,12 @@
  */
 namespace SWL;
 
-use Hooks;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMWDataItem;
 use SMW\SemanticData;
-use Title;
 
 class ChangeSet {
 

--- a/src/Edit.php
+++ b/src/Edit.php
@@ -13,10 +13,9 @@
  */
 namespace SWL;
 
-use Hooks;
 use MediaWiki\MediaWikiServices;
-use Title;
-use User;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 
 class Edit {
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -15,6 +15,8 @@ namespace SWL;
 
 use Hooks;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use SMW\DIWikiPage;
 use SMW\Query\QueryResult;
 use SMW\Query\Language\ConceptDescription;
@@ -22,8 +24,6 @@ use SMW\Query\Language\Conjunction;
 use SMW\Query\Language\ValueDescription;
 use SMW\DIProperty;
 use SMWQuery;
-use Title;
-use User;
 
 class Group {
 

--- a/src/Groups.php
+++ b/src/Groups.php
@@ -14,8 +14,8 @@
 namespace SWL;
 
 use MediaWiki\MediaWikiServices;
-use Title;
-use User;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 
 final class Groups {
 

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -9,9 +9,9 @@ use SWL\MediaWiki\Hooks\ExtensionSchemaUpdater;
 use SWL\TableUpdater;
 use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use MediaWiki\User\UserIdentity;
-use User;
-use Title;
 use Language;
 
 /**

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -17,12 +17,12 @@ use AlItem;
 use ALRow;
 use ALTree;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use RequestContext;
 use Sanitizer;
 use SMW\SemanticData;
 use SMW\Store;
-use Title;
-use User;
 
 final class Hooks {
 

--- a/src/MediaWiki/Hooks/SkinTemplateNavigationUniversal.php
+++ b/src/MediaWiki/Hooks/SkinTemplateNavigationUniversal.php
@@ -3,8 +3,8 @@
 namespace SWL\MediaWiki\Hooks;
 
 use MediaWiki\User\UserOptionsManager;
-use Title;
-use User;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 
 /**
  * Called after the navigation links have been set up, before they are shown.

--- a/tests/phpunit/Integration/HookRegistryTest.php
+++ b/tests/phpunit/Integration/HookRegistryTest.php
@@ -69,7 +69,7 @@ class HookRegistryTest extends MediaWikiIntegrationTestCase {
 
 	private function doTestSkinTemplateNavigationUniversal( $hooks, $user ) {
 
-		$title = $this->getMockBuilder( '\Title' )
+		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Integration/HookRegistryTest.php
+++ b/tests/phpunit/Integration/HookRegistryTest.php
@@ -4,9 +4,9 @@ namespace SWL\Tests;
 
 use MediaWiki\HookContainer\HookContainer;
 use MediaWikiIntegrationTestCase;
+use MediaWiki\Title\Title;
 use SWL\HookRegistry;
 use SMW\DIWikiPage;
-use Title;
 
 /**
  * @covers \SWL\HookRegistry

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinTemplateNavigationUniversalTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinTemplateNavigationUniversalTest.php
@@ -3,6 +3,7 @@
 namespace SWL\Tests\MediaWiki\Hooks;
 
 use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use MediaWiki\User\UserOptionsManager;
 use SWL\MediaWiki\Hooks\SkinTemplateNavigationUniversal;
 
@@ -25,11 +26,11 @@ class SkinTemplateNavigationUniversalTest extends \PHPUnit\Framework\TestCase {
 
 		$personalUrls = [];
 
-		$title = $this->getMockBuilder( 'Title' )
+		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$user = $this->getMockBuilder( 'User' )
+		$user = $this->getMockBuilder( User::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -48,7 +49,7 @@ class SkinTemplateNavigationUniversalTest extends \PHPUnit\Framework\TestCase {
 
 		$title = Title::newFromText( __METHOD__ );
 
-		$user = $this->getMockBuilder( '\User' )
+		$user = $this->getMockBuilder( User::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -76,7 +77,7 @@ class SkinTemplateNavigationUniversalTest extends \PHPUnit\Framework\TestCase {
 
 		$title = Title::newFromText( __METHOD__ );
 
-		$user = $this->getMockBuilder( '\User' )
+		$user = $this->getMockBuilder( User::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -96,7 +97,7 @@ class SkinTemplateNavigationUniversalTest extends \PHPUnit\Framework\TestCase {
 
 		$title = Title::newFromText( __METHOD__ );
 
-		$user = $this->getMockBuilder( '\User' )
+		$user = $this->getMockBuilder( User::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinTemplateNavigationUniversalTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinTemplateNavigationUniversalTest.php
@@ -2,9 +2,9 @@
 
 namespace SWL\Tests\MediaWiki\Hooks;
 
+use MediaWiki\Title\Title;
 use MediaWiki\User\UserOptionsManager;
 use SWL\MediaWiki\Hooks\SkinTemplateNavigationUniversal;
-use Title;
 
 /**
  * @covers \SWL\MediaWiki\Hooks\SkinTemplateNavigationUniversal


### PR DESCRIPTION
* Adds MW 1.44 and 1.45 support.
* Drop MW 1.39-1.42 support.
* Bumps php version to 8.2 since the CI we have only uses 8.2+ now.